### PR TITLE
Allow continued beer recommendations

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,12 +55,17 @@ async def photo_received(message: types.Message, state: FSMContext) -> None:
     result = process_image(path, preference)
     await message.answer(result)
 
+    await message.answer(
+        "Хочешь ещё рекомендаций? Напиши новые предпочтения или пришли другое фото."
+    )
+
+    await state.clear()
+    await state.set_state(Form.waiting_for_preference)
+
     try:
         path.unlink()
     except OSError as exc:
         logger.error("Cannot delete photo %s: %s", path, exc)
-
-    await state.clear()
 
 
 @dp.message(Form.waiting_for_photo)


### PR DESCRIPTION
## Summary
- update bot to repeat preference query after sending result
- reset conversation state to enable requesting more recommendations

## Testing
- `python -m py_compile main.py pipeline.py utils.py segmenter/model.py classifier/model.py referrer/model.py`


------
https://chatgpt.com/codex/tasks/task_e_685e1021f0448329a1afb21ef1e382ca